### PR TITLE
Added refund bank balance on island disband

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -1138,6 +1138,8 @@ public final class SIsland implements Island {
             }).forEach(superiorPlayer::resetMission);
         });
 
+        plugin.getProviders().depositMoney(getOwner(), islandBank.getBalance());
+
         plugin.getMissions().getAllMissions().forEach(this::resetMission);
 
         resetChunks(true);


### PR DESCRIPTION
When you disband your island, the balance will now be refunded to the owner of the island. (https://trello.com/c/V5kzyJiA)

I was originally using `islandBank.withdrawMoney(getOwner(), islandBank.getBalance(), null)`, but the message "Bank: BomBardyGamer has withdrawn $100,000 from the island bank" or whatever it is felt a bit out of place.

Feel free to request changes if you want.

Edit: I have tested this with both `/is disband` and `/is admin disband` using Essentials + Vault for economy (though any economy that supports Vault should work of course).