### PR TITLE
Added teleport warmup bypass permission

### DIFF
--- a/src/main/java/com/bgsoftware/superiorskyblock/commands/CmdTeleport.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/commands/CmdTeleport.java
@@ -63,7 +63,7 @@ public final class CmdTeleport implements ISuperiorCommand {
 
         SuperiorPlayer superiorPlayer = arguments.getValue();
 
-        if(plugin.getSettings().homeWarmup > 0 && !superiorPlayer.hasBypassModeEnabled()) {
+        if(plugin.getSettings().homeWarmup > 0 && !superiorPlayer.hasBypassModeEnabled() && !superiorPlayer.hasPermission("superior.admin.bypass.warmup")) {
             Locale.TELEPORT_WARMUP.send(superiorPlayer, StringUtils.formatTime(superiorPlayer.getUserLocale(), plugin.getSettings().homeWarmup));
             ((SPlayerDataHandler) superiorPlayer.getDataHandler()).setTeleportTask(Executor.sync(() ->
                     teleportToIsland(superiorPlayer, island), plugin.getSettings().homeWarmup / 50));

--- a/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
+++ b/src/main/java/com/bgsoftware/superiorskyblock/island/SIsland.java
@@ -2649,7 +2649,7 @@ public final class SIsland implements Island {
 
     @Override
     public void warpPlayer(SuperiorPlayer superiorPlayer, String warp){
-        if(plugin.getSettings().warpsWarmup > 0 && !superiorPlayer.hasBypassModeEnabled()) {
+        if(plugin.getSettings().warpsWarmup > 0 && !superiorPlayer.hasBypassModeEnabled() && !superiorPlayer.hasPermission("superior.admin.bypass.warmup")) {
             Locale.TELEPORT_WARMUP.send(superiorPlayer, StringUtils.formatTime(superiorPlayer.getUserLocale(), plugin.getSettings().warpsWarmup));
             ((SPlayerDataHandler) superiorPlayer.getDataHandler()).setTeleportTask(Executor.sync(() ->
                     warpPlayerWithoutWarmup(superiorPlayer, warp), plugin.getSettings().warpsWarmup / 50));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -170,9 +170,8 @@ permissions:
             description: Grant a bonus to a player.
           superior.admin.bypass:
             description: Toggle bypass mode.
-            children:
-              superior.admin.bypass.warmup:
-                description: Bypass teleport warmup
+          superior.admin.bypass.warmup:
+            description: Bypass teleport warmup
           superior.admin.chest:
             description: Open island's chest of another island.
           superior.admin.cleargenerator:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -170,6 +170,9 @@ permissions:
             description: Grant a bonus to a player.
           superior.admin.bypass:
             description: Toggle bypass mode.
+            children:
+              superior.admin.bypass.warmup:
+                description: Bypass teleport warmup
           superior.admin.chest:
             description: Open island's chest of another island.
           superior.admin.cleargenerator:


### PR DESCRIPTION
When you either warp (/is warp) or teleport (/is home) to an island, there is now a permission (`superior.admin.bypass.warmup`) to bypass the warmup sequence (https://trello.com/c/O9K2hD7t).

Fully tested on Paper 1.12.2 with and without permission, using LuckPerms + Vault for permissions.